### PR TITLE
feature/default-batch-size

### DIFF
--- a/aics_dask_utils/__init__.py
+++ b/aics_dask_utils/__init__.py
@@ -13,4 +13,4 @@ def get_module_version():
     return __version__
 
 
-from .distributed_handler import DistributedHandler  # noqa: F401
+from .distributed_handler import DEFAULT_MAX_THREADS, DistributedHandler  # noqa: F401

--- a/aics_dask_utils/tests/test_distributed_handler.py
+++ b/aics_dask_utils/tests/test_distributed_handler.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import pytest
-from aics_dask_utils import DistributedHandler
-
 from concurrent.futures import ThreadPoolExecutor
+
+import pytest
 from distributed import Client, LocalCluster
+
+from aics_dask_utils import DEFAULT_MAX_THREADS, DistributedHandler
 
 
 @pytest.mark.parametrize(
@@ -69,3 +70,19 @@ def test_distributed_handler_distributed(values, expected_values):
         handler_map_results == handler_batched_results
         and handler_map_results == distributed_results
     )
+
+    cluster.close()
+
+
+def test_get_batch_size_threadpool():
+    with DistributedHandler() as handler:
+        assert handler._get_batch_size(handler.client) == DEFAULT_MAX_THREADS
+
+
+def test_get_batch_size_distributed():
+    cluster = LocalCluster(processes=False)
+
+    with DistributedHandler(cluster.scheduler_address) as handler:
+        assert handler._get_batch_size(handler.client) == DEFAULT_MAX_THREADS
+
+    cluster.close()


### PR DESCRIPTION
Instead of setting up the default batch size by hand each time where the most common operation we are currently doing is matching batch size to the number of workers. Just do that for us by default.