### PR TITLE
Fix typo in dependency list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup_requirements = [
 ]
 
 dev_requirements = [
-    "black>=19.10b0"
+    "black>=19.10b0",
     "bumpversion>=0.5.3",
     "coverage>=5.0a4",
     "flake8>=3.7.7",


### PR DESCRIPTION
# Issue
`aics-dask-utils` has a simple typo in the `dev_requirements` that prevents installation via PDM (v2.8.2) and causes warnings in Poetry (v1.5.1). 

Steps to reproduce:
* Use python 3.8
* Install [PDM](https://pdm.fming.dev/latest/)
* In a new directory, run `pdm init`
* Then run:
```bash
$ pdm add aics-dask-utils
Adding packages to default dependencies: aics-dask-utils See /tmp/pdm-lock-3vg2w8es.log for detailed debug log. [RequirementError]: Expected matching RIGHT_PARENTHESIS for LEFT_PARENTHESIS, after version specifier
    black (>=19.10b0bumpversion>=0.5.3) ; extra == 'all'
          ~~~~~~~~~~^
```

# Testing
None beyond the following quick check of how this typo interacts with the `*` operator (python 3.8.13):
```python
>>> print([ *[
...     "black>=19.10b0"
...     "bumpversion>=0.5.3",
...     "coverage>=5.0a4"
... ]])
['black>=19.10b0bumpversion>=0.5.3', 'coverage>=5.0a4']
>>> print([ *[
...     "black>=19.10b0",
...     "bumpversion>=0.5.3",
...     "coverage>=5.0a4"
... ]])
['black>=19.10b0', 'bumpversion>=0.5.3', 'coverage>=5.0a4']
```
