### PR TITLE
Upgrade publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: aicspypi
         password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
My last PR [failed to publish](https://github.com/AllenCellModeling/aics_dask_utils/actions/runs/5731212217). Hopefully this works.

The Test and Lint job and the Docs job are both also broken, but I'm not planning to fix them as this repo is basically unmaintained and likely to be deprecated. (The tests do pass for me locally)