### PR TITLE
Attempt to fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,5 +24,5 @@ jobs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: aicspypi
+        user: __token__
         password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -29,10 +29,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Two changes here:
1. Try again to fix the PyPi publish action (following the pattern used in [aics-shparam](https://github.com/AllenCell/aics-shparam/blob/main/.github/workflows/build-main.yml))
2. Remove old python versions from the test matrix because they were failing