### PR TITLE
Switch to PyPi trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      # this permission is mandatory for trusted publishing
+      id-token: write
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
@@ -23,6 +26,3 @@ jobs:
         python setup.py sdist bdist_wheel
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
My [previous](https://github.com/AllenCellModeling/aics_dask_utils/pull/6) [attempts](https://github.com/AllenCellModeling/aics_dask_utils/pull/7) to get this repo's PyPi publish action working failed. Now @griffinfujioka has configured this repo for the new PyPi trusted publishing from Github Actions. This PR starts using the trusted publishing mechanism by making the [recommended changes](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/#using-trusted-publishing-with-github-actions).